### PR TITLE
feat: add changelog and version automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.0.0] - 2025-08-19
+### 📦 Phase 0.0
+- Initial changelog creation.
+
+### Rollback
+- Revert this commit using `git revert <commit>`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:ui": "vitest --ui",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "release": "node scripts/updateChangelog.js"
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",

--- a/scripts/updateChangelog.js
+++ b/scripts/updateChangelog.js
@@ -1,0 +1,15 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import pkg from '../package.json' assert { type: 'json' }
+
+const changelogPath = join(process.cwd(), 'CHANGELOG.md')
+const changelog = readFileSync(changelogPath, 'utf8')
+const versionHeader = `## [${pkg.version}] - ${new Date().toISOString().split('T')[0]}`
+
+if (!changelog.includes(versionHeader)) {
+  const entry = `\n${versionHeader}\n### 📦 Phase 0.0\n- Describe changes here.\n\n### Rollback\n- Revert to previous version using git.\n`
+  writeFileSync(changelogPath, changelog.trimEnd() + entry)
+  console.log('CHANGELOG updated')
+} else {
+  console.log('CHANGELOG already contains current version')
+}

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,3 +1,4 @@
+// v0.0.0
 import { VALIDATION_RULES } from '../constants'
 
 /**


### PR DESCRIPTION
## Summary
- add root CHANGELOG with phase info and rollback steps
- note version in validation logic
- script to auto-update changelog on release

## Testing
- `npm run release`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d23839a0832188818d801d80e48e