### PR TITLE
Add offline service worker and task service integration

### DIFF
--- a/docs/platform/service-worker.md
+++ b/docs/platform/service-worker.md
@@ -1,0 +1,46 @@
+# Service Worker (Offline) - Feature Flagged
+
+This codebase includes a service worker for offline caching and request queueing. It is disabled by default and can be enabled via configuration.
+
+## Enabling in Production
+
+1) Build and serve `static/service-worker.js` at `/static/service-worker.js` (already in repo)
+2) Enable the feature flag in your deployment by setting the global before the app loads:
+
+Add to the hosting HTML page before the bundle script tag:
+
+```html
+<script>
+  window.__SW_ENABLED__ = true;
+</script>
+```
+
+You can also inject this via your hosting platform’s HTML template or env-driven templating.
+
+## Behavior
+
+- GET /api/projects and /api/tasks requests are cached
+- Mutations (POST/PUT/DELETE to /api/projects or /api/tasks) are queued via IndexedDB if offline and re-sent on sync
+- If offline on GET, returns cached response when available, else 503
+
+## Safety considerations
+
+- localStorage operations are not intercepted; the service worker only handles /api/*
+- Request queue is stored in IndexedDB `sizewise-queue` in store `requests`
+- Service worker registration occurs only when APP_CONFIG.FEATURES.SERVICE_WORKER is true
+
+## Local testing
+
+- Temporarily enable flag in dev by opening the browser console and setting:
+
+```js
+window.__SW_ENABLED__ = true; location.reload();
+```
+
+- Use DevTools Application > Service Workers and Network Offline toggle to simulate offline
+
+## Disable
+
+- Set `window.__SW_ENABLED__ = false` (default) or remove the script tag
+- Unregister in browser DevTools if needed
+

--- a/src/components/TaskManager.jsx
+++ b/src/components/TaskManager.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useApp } from '../context/AppContext';
 import { useTranslation } from '../i18n';
+import { taskService } from '../services/api.js';
 
 export default function TaskManager({ projectId, onClose }) {
   const { state, actions } = useApp();
@@ -26,20 +27,16 @@ export default function TaskManager({ projectId, onClose }) {
 
   const loadProjectTasks = async () => {
     try {
-      // Use the task service to get tasks for this project
-      const result = await fetch(`/api/tasks/project/${projectId}`);
-      if (result.ok) {
-        const data = await result.json();
-        setTasks(data.data || []);
+      const result = await taskService.getByProject(projectId);
+      if (result.success) {
+        setTasks(result.data || []);
       } else {
-        // Fallback: get all tasks and filter by project
         const allTasks = JSON.parse(localStorage.getItem('sizewise_tasks') || '[]');
         const projectTasks = allTasks.filter(task => task.projectId === projectId);
         setTasks(projectTasks);
       }
     } catch (error) {
       console.error('Failed to load tasks:', error);
-      // Fallback to localStorage
       const allTasks = JSON.parse(localStorage.getItem('sizewise_tasks') || '[]');
       const projectTasks = allTasks.filter(task => task.projectId === projectId);
       setTasks(projectTasks);

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -5,6 +5,9 @@ export const APP_CONFIG = {
   VERSION: '1.0.0',
   AUTO_REFRESH_INTERVAL: 30000, // 30 seconds
   SESSION_TIMEOUT: 24 * 60 * 60 * 1000, // 24 hours
+  FEATURES: {
+    SERVICE_WORKER: (typeof window !== 'undefined' ? (window.__SW_ENABLED__ ?? false) : false)
+  }
 }
 
 export const STORAGE_KEYS = {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,3 +9,11 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <App />
   </React.StrictMode>,
 )
+
+if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/static/service-worker.js').catch(err => {
+      console.error('Service worker registration failed:', err)
+    })
+  })
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,7 +10,10 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   </React.StrictMode>,
 )
 
-if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+
+// Feature-flagged service worker registration
+import { APP_CONFIG } from './constants/index.js'
+if (APP_CONFIG.FEATURES.SERVICE_WORKER && typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/static/service-worker.js').catch(err => {
       console.error('Service worker registration failed:', err)

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,108 @@
+const CACHE_NAME = 'sizewise-cache-v1';
+const QUEUE_DB = 'sizewise-queue';
+const QUEUE_STORE = 'requests';
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+  event.waitUntil(caches.open(CACHE_NAME));
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (url.pathname.startsWith('/api/projects') || url.pathname.startsWith('/api/tasks')) {
+    if (request.method === 'GET') {
+      event.respondWith(handleGetRequest(request));
+    } else if (['POST', 'PUT', 'DELETE'].includes(request.method)) {
+      event.respondWith(handleMutatingRequest(request));
+    }
+  }
+});
+
+async function handleGetRequest(request) {
+  const cache = await caches.open(CACHE_NAME);
+  try {
+    const response = await fetch(request);
+    cache.put(request, response.clone());
+    processQueue();
+    return response;
+  } catch (err) {
+    const cached = await cache.match(request);
+    return cached || new Response(null, { status: 503 });
+  }
+}
+
+async function handleMutatingRequest(request) {
+  try {
+    return await fetch(request);
+  } catch (err) {
+    await queueRequest(request);
+    return new Response(JSON.stringify({ queued: true }), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}
+
+async function queueRequest(request) {
+  const db = await openDB();
+  const tx = db.transaction(QUEUE_STORE, 'readwrite');
+  const store = tx.objectStore(QUEUE_STORE);
+  const body = await request.clone().json().catch(() => null);
+  const headers = [...request.headers];
+  store.add({ url: request.url, method: request.method, headers, body });
+  await promisify(tx);
+  await self.registration.sync.register('sizewise-sync');
+}
+
+self.addEventListener('sync', event => {
+  if (event.tag === 'sizewise-sync') {
+    event.waitUntil(processQueue());
+  }
+});
+
+async function processQueue() {
+  const db = await openDB();
+  const tx = db.transaction(QUEUE_STORE, 'readwrite');
+  const store = tx.objectStore(QUEUE_STORE);
+  const all = await getAll(store);
+  for (const entry of all) {
+    await fetch(entry.url, {
+      method: entry.method,
+      headers: new Headers(entry.headers),
+      body: entry.body ? JSON.stringify(entry.body) : undefined
+    });
+  }
+  store.clear();
+  await promisify(tx);
+}
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(QUEUE_DB, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(QUEUE_STORE, { autoIncrement: true });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function getAll(store) {
+  return new Promise((resolve, reject) => {
+    const req = store.getAll();
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function promisify(tx) {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}


### PR DESCRIPTION
## Summary
- replace direct task fetch with `taskService.getByProject`
- add service worker for caching and offline request queue
- register service worker during app startup

## Testing
- `npm test` *(fails: vitest not found; npm install 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d39b7a9083218a875eb3afb37be1