### PR TITLE
test: add project and task tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:ui": "vitest --ui",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "e2e": "node src/test/e2e/project-task.e2e.js"
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",

--- a/src/components/__tests__/ProjectCreationModal.test.jsx
+++ b/src/components/__tests__/ProjectCreationModal.test.jsx
@@ -1,0 +1,123 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import ProjectCreationModal from '../ProjectCreationModal.jsx';
+
+const mockCreate = vi.fn().mockResolvedValue({ success: true });
+const mockUpdate = vi.fn().mockResolvedValue({ success: true });
+
+vi.mock('../../context/AppContext', () => ({
+  useApp: () => ({
+    actions: {
+      createProject: mockCreate,
+      updateProject: mockUpdate,
+    },
+  }),
+}));
+
+const renderModal = (props = {}) => {
+  const defaultProps = { isOpen: true, onClose: vi.fn() };
+  return render(<ProjectCreationModal {...defaultProps} {...props} />);
+};
+
+describe('ProjectCreationModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('validates required fields and shows errors', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole('button', { name: /create project/i }));
+
+    expect(await screen.findByText(/project name is required/i)).toBeInTheDocument();
+    expect(await screen.findByText(/start date is required/i)).toBeInTheDocument();
+    expect(await screen.findByText(/due date is required/i)).toBeInTheDocument();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test('creates new project with valid data', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderModal({ onClose });
+
+    await user.type(screen.getByLabelText(/project name/i), ' New Project ');
+    await user.type(screen.getByLabelText(/start date/i), '2024-01-01');
+    await user.type(screen.getByLabelText(/due date/i), '2024-01-10');
+
+    await user.click(screen.getByRole('button', { name: /create project/i }));
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith({
+        name: 'New Project',
+        description: null,
+        location: null,
+        startDate: '2024-01-01',
+        dueDate: '2024-01-10',
+        priority: 'medium',
+        tags: [],
+      });
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  test('updates existing project in edit mode', async () => {
+    const user = userEvent.setup();
+    const project = {
+      id: 1,
+      name: 'Old Name',
+      description: 'desc',
+      location: 'loc',
+      startDate: '2024-02-01',
+      dueDate: '2024-02-10',
+      priority: 'high',
+      tags: ['x'],
+    };
+    renderModal({ project, mode: 'edit' });
+
+    const nameInput = screen.getByLabelText(/project name/i);
+    expect(nameInput).toHaveValue('Old Name');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Updated');
+
+    await user.click(screen.getByRole('button', { name: /update project/i }));
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(1, {
+        name: 'Updated',
+        description: 'desc',
+        location: 'loc',
+        startDate: '2024-02-01',
+        dueDate: '2024-02-10',
+        priority: 'high',
+        tags: ['x'],
+      });
+    });
+  });
+
+  test('shows error when due date before start date', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(screen.getByLabelText(/project name/i), 'Edge Project');
+    await user.type(screen.getByLabelText(/start date/i), '2024-01-10');
+    await user.type(screen.getByLabelText(/due date/i), '2024-01-01');
+
+    await user.click(screen.getByRole('button', { name: /create project/i }));
+
+    expect(await screen.findByText(/due date must be after start date/i)).toBeInTheDocument();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test('closes when escape key pressed', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderModal({ onClose });
+
+    await user.keyboard('{Escape}');
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+

--- a/src/components/__tests__/TaskManager.test.jsx
+++ b/src/components/__tests__/TaskManager.test.jsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import TaskManager from '../TaskManager.jsx';
+
+const mockCreateTask = vi.fn().mockResolvedValue({ success: true });
+const mockUpdateTask = vi.fn().mockResolvedValue({ success: true });
+const mockDeleteTask = vi.fn().mockResolvedValue({ success: true });
+
+vi.mock('../../context/AppContext', () => ({
+  useApp: () => ({
+    state: {},
+    actions: {
+      createTask: mockCreateTask,
+      updateTask: mockUpdateTask,
+      deleteTask: mockDeleteTask,
+    },
+  }),
+}));
+
+const sampleTasks = [
+  { id: 1, projectId: 1, title: 'Task A', status: 'todo', priority: 'low' },
+];
+
+describe('TaskManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: sampleTasks }),
+    });
+  });
+
+  test('loads tasks on mount', async () => {
+    render(<TaskManager projectId={1} onClose={vi.fn()} />);
+
+    expect(fetch).toHaveBeenCalledWith('/api/tasks/project/1');
+    await waitFor(() => {
+      expect(screen.getByText('Task A')).toBeInTheDocument();
+    });
+  });
+
+  test('creates a new task', async () => {
+    const user = userEvent.setup();
+    render(<TaskManager projectId={1} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Task A'));
+
+    await user.click(screen.getByRole('button', { name: /add task/i }));
+    await user.type(screen.getByLabelText(/task title/i), 'New Task');
+    await user.click(screen.getByRole('button', { name: /create task/i }));
+
+    await waitFor(() => {
+      expect(mockCreateTask).toHaveBeenCalledWith({
+        title: 'New Task',
+        description: '',
+        priority: 'medium',
+        status: 'todo',
+        dueDate: '',
+        assigneeId: null,
+        projectId: 1,
+      });
+    });
+  });
+
+  test('edits an existing task', async () => {
+    const user = userEvent.setup();
+    render(<TaskManager projectId={1} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Task A'));
+
+    await user.click(screen.getByTitle('Edit task'));
+    const titleInput = screen.getByLabelText(/task title/i);
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Task A Updated');
+    await user.click(screen.getByRole('button', { name: /update task/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith(1, {
+        title: 'Task A Updated',
+        description: '',
+        priority: 'low',
+        status: 'todo',
+        dueDate: '',
+        assigneeId: null,
+        projectId: 1,
+      });
+    });
+  });
+
+  test('deletes a task', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<TaskManager projectId={1} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Task A'));
+
+    await user.click(screen.getByTitle('Delete task'));
+
+    await waitFor(() => {
+      expect(mockDeleteTask).toHaveBeenCalledWith(1);
+    });
+  });
+
+  test('updates task status', async () => {
+    const user = userEvent.setup();
+    render(<TaskManager projectId={1} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText('Task A'));
+
+    const statusSelect = screen.getByDisplayValue('todo');
+    await user.selectOptions(statusSelect, 'completed');
+
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith(1, { status: 'completed' });
+    });
+  });
+});
+

--- a/src/test/e2e/project-task.e2e.js
+++ b/src/test/e2e/project-task.e2e.js
@@ -1,0 +1,27 @@
+import puppeteer from 'puppeteer';
+
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+try {
+  // Navigate to dev server
+  await page.goto('http://localhost:5173');
+
+  // Create project
+  await page.click('button:has-text("New Project")');
+  await page.fill('#name', 'E2E Project');
+  await page.fill('#startDate', '2024-01-01');
+  await page.fill('#dueDate', '2024-01-10');
+  await page.click('button:has-text("Create Project")');
+  await page.waitForSelector('text=E2E Project');
+
+  // Open task manager
+  await page.click(`button[aria-label="Manage tasks for E2E Project"]`);
+  await page.click('button:has-text("Add Task")');
+  await page.fill('input[type="text"]', 'First Task');
+  await page.click('button:has-text("Create Task")');
+  await page.waitForSelector('text=First Task');
+} catch (err) {
+  console.error('E2E test failed:', err);
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## Summary
- add coverage-focused tests for ProjectCreationModal
- exercise TaskManager CRUD and status transitions
- add Puppeteer E2E script for project and task flows

## Testing
- `node node_modules/vitest/vitest.mjs run src/components/__tests__/ProjectCreationModal.test.jsx src/components/__tests__/TaskManager.test.jsx --coverage` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run e2e` *(fails: Failed to launch the browser process: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d3b61da08321bd8cbdbe190f4fde