### PR TITLE
feat: add basic i18n support

### DIFF
--- a/app/docs/i18n/README.md
+++ b/app/docs/i18n/README.md
@@ -1,0 +1,41 @@
+# Internationalization Guide
+
+This directory documents how translations are managed in the SizeWise Suite.
+
+## Translation Files
+
+Locale files live in `/app/i18n/` and are plain JSON maps. Example languages:
+
+- `en.json` – English (default)
+- `es.json` – Spanish
+
+Each file mirrors the same key structure. Add additional locales by creating new JSON files with the same keys.
+
+## Using Translations
+
+Components access translations through the `useTranslation` hook:
+
+```jsx
+import { useTranslation } from '../../src/i18n'
+
+function Example() {
+  const { t } = useTranslation()
+  return <h1>{t('project.create')}</h1>
+}
+```
+
+`useTranslation` returns the current language and a setter if runtime language switching is required.
+
+## Adding Keys
+
+1. Define the key in every locale file.
+2. Reference the key with `t('path.to.key')` in components.
+
+## Switching Languages
+
+```jsx
+const { setLanguage } = useTranslation()
+setLanguage('es') // switch to Spanish
+```
+
+The hook will re-render components when the language changes.

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1,0 +1,46 @@
+{
+  "task": {
+    "management": "Task Management",
+    "add": "+ Add Task",
+    "edit": "Edit Task",
+    "create": "Create New Task",
+    "title": "Task Title *",
+    "description": "Description",
+    "priority": "Priority",
+    "status": "Status",
+    "dueDate": "Due Date",
+    "update": "Update Task",
+    "createButton": "Create Task",
+    "none": "No tasks yet. Create your first task to get started!",
+    "editTitle": "Edit task",
+    "deleteTitle": "Delete task",
+    "confirmDelete": "Are you sure you want to delete this task?"
+  },
+  "project": {
+    "edit": "Edit Project",
+    "create": "Create New Project",
+    "name": "Project Name",
+    "namePlaceholder": "Enter project name",
+    "description": "Description",
+    "descriptionPlaceholder": "Enter project description",
+    "location": "Location",
+    "locationPlaceholder": "Enter project location",
+    "startDate": "Start Date",
+    "dueDate": "Due Date",
+    "priority": "Priority",
+    "update": "Update Project",
+    "createButton": "Create Project",
+    "updating": "Updating...",
+    "creating": "Creating..."
+  },
+  "general": {
+    "low": "Low",
+    "medium": "Medium",
+    "high": "High",
+    "cancel": "Cancel",
+    "toDo": "To Do",
+    "inProgress": "In Progress",
+    "review": "Review",
+    "completed": "Completed"
+  }
+}

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1,0 +1,46 @@
+{
+  "task": {
+    "management": "Gestión de Tareas",
+    "add": "+ Agregar Tarea",
+    "edit": "Editar Tarea",
+    "create": "Crear Nueva Tarea",
+    "title": "Título de la Tarea *",
+    "description": "Descripción",
+    "priority": "Prioridad",
+    "status": "Estado",
+    "dueDate": "Fecha de Vencimiento",
+    "update": "Actualizar Tarea",
+    "createButton": "Crear Tarea",
+    "none": "No hay tareas aún. ¡Crea tu primera tarea para comenzar!",
+    "editTitle": "Editar tarea",
+    "deleteTitle": "Eliminar tarea",
+    "confirmDelete": "¿Estás seguro de que deseas eliminar esta tarea?"
+  },
+  "project": {
+    "edit": "Editar Proyecto",
+    "create": "Crear Nuevo Proyecto",
+    "name": "Nombre del Proyecto",
+    "namePlaceholder": "Ingrese el nombre del proyecto",
+    "description": "Descripción",
+    "descriptionPlaceholder": "Ingrese la descripción del proyecto",
+    "location": "Ubicación",
+    "locationPlaceholder": "Ingrese la ubicación del proyecto",
+    "startDate": "Fecha de Inicio",
+    "dueDate": "Fecha de Entrega",
+    "priority": "Prioridad",
+    "update": "Actualizar Proyecto",
+    "createButton": "Crear Proyecto",
+    "updating": "Actualizando...",
+    "creating": "Creando..."
+  },
+  "general": {
+    "low": "Baja",
+    "medium": "Media",
+    "high": "Alta",
+    "cancel": "Cancelar",
+    "toDo": "Por Hacer",
+    "inProgress": "En Progreso",
+    "review": "Revisión",
+    "completed": "Completado"
+  }
+}

--- a/src/components/ProjectCreationModal.jsx
+++ b/src/components/ProjectCreationModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useApp } from '../context/AppContext';
+import { useTranslation } from '../i18n';
 
 export default function ProjectCreationModal({ isOpen, onClose, project = null, mode = 'create' }) {
   const { actions } = useApp();
@@ -14,6 +15,7 @@ export default function ProjectCreationModal({ isOpen, onClose, project = null, 
   });
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { t } = useTranslation();
 
   // Reset form when modal opens/closes or populate with project data for editing
   useEffect(() => {
@@ -148,14 +150,14 @@ export default function ProjectCreationModal({ isOpen, onClose, project = null, 
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal-content" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h2>{mode === 'edit' ? 'Edit Project' : 'Create New Project'}</h2>
+          <h2>{mode === 'edit' ? t('project.edit') : t('project.create')}</h2>
           <button className="modal-close" onClick={onClose}>×</button>
         </div>
 
         <form onSubmit={handleSubmit} className="project-form">
           {/* Project Name */}
           <div className="form-group">
-            <label htmlFor="name">Project Name *</label>
+            <label htmlFor="name">{t('project.name')} *</label>
             <input
               type="text"
               id="name"
@@ -163,7 +165,7 @@ export default function ProjectCreationModal({ isOpen, onClose, project = null, 
               value={formData.name}
               onChange={handleChange}
               className={errors.name ? 'error' : ''}
-              placeholder="Enter project name"
+              placeholder={t('project.namePlaceholder')}
               maxLength={120}
               autoFocus
             />
@@ -172,14 +174,14 @@ export default function ProjectCreationModal({ isOpen, onClose, project = null, 
 
           {/* Description */}
           <div className="form-group">
-            <label htmlFor="description">Description</label>
+            <label htmlFor="description">{t('project.description')}</label>
             <textarea
               id="description"
               name="description"
               value={formData.description}
               onChange={handleChange}
               className={errors.description ? 'error' : ''}
-              placeholder="Enter project description"
+              placeholder={t('project.descriptionPlaceholder')}
               rows={3}
               maxLength={2000}
             />
@@ -188,21 +190,21 @@ export default function ProjectCreationModal({ isOpen, onClose, project = null, 
 
           {/* Location */}
           <div className="form-group">
-            <label htmlFor="location">Location</label>
+            <label htmlFor="location">{t('project.location')}</label>
             <input
               type="text"
               id="location"
               name="location"
               value={formData.location}
               onChange={handleChange}
-              placeholder="Enter project location"
+              placeholder={t('project.locationPlaceholder')}
             />
           </div>
 
           {/* Dates */}
           <div className="form-row">
             <div className="form-group">
-              <label htmlFor="startDate">Start Date *</label>
+              <label htmlFor="startDate">{t('project.startDate')} *</label>
               <input
                 type="date"
                 id="startDate"
@@ -215,7 +217,7 @@ export default function ProjectCreationModal({ isOpen, onClose, project = null, 
             </div>
 
             <div className="form-group">
-              <label htmlFor="dueDate">Due Date *</label>
+              <label htmlFor="dueDate">{t('project.dueDate')} *</label>
               <input
                 type="date"
                 id="dueDate"
@@ -230,23 +232,23 @@ export default function ProjectCreationModal({ isOpen, onClose, project = null, 
 
           {/* Priority */}
           <div className="form-group">
-            <label htmlFor="priority">Priority</label>
+            <label htmlFor="priority">{t('project.priority')}</label>
             <select
               id="priority"
               name="priority"
               value={formData.priority}
               onChange={handleChange}
             >
-              <option value="low">Low</option>
-              <option value="medium">Medium</option>
-              <option value="high">High</option>
+              <option value="low">{t('general.low')}</option>
+              <option value="medium">{t('general.medium')}</option>
+              <option value="high">{t('general.high')}</option>
             </select>
           </div>
 
           {/* Form Actions */}
           <div className="form-actions">
             <button type="button" className="btn-secondary" onClick={onClose}>
-              Cancel
+              {t('general.cancel')}
             </button>
             <button
               type="submit"
@@ -254,8 +256,8 @@ export default function ProjectCreationModal({ isOpen, onClose, project = null, 
               disabled={isSubmitting}
             >
               {isSubmitting
-                ? (mode === 'edit' ? 'Updating...' : 'Creating...')
-                : (mode === 'edit' ? 'Update Project' : 'Create Project')
+                ? (mode === 'edit' ? t('project.updating') : t('project.creating'))
+                : (mode === 'edit' ? t('project.update') : t('project.createButton'))
               }
             </button>
           </div>

--- a/src/components/TaskManager.jsx
+++ b/src/components/TaskManager.jsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react';
 import { useApp } from '../context/AppContext';
+import { useTranslation } from '../i18n';
 
 export default function TaskManager({ projectId, onClose }) {
   const { state, actions } = useApp();
   const [tasks, setTasks] = useState([]);
   const [showTaskForm, setShowTaskForm] = useState(false);
   const [editingTask, setEditingTask] = useState(null);
+  const { t } = useTranslation();
   const [formData, setFormData] = useState({
     title: '',
     description: '',
@@ -92,7 +94,7 @@ export default function TaskManager({ projectId, onClose }) {
   };
 
   const handleDelete = async (taskId) => {
-    if (window.confirm('Are you sure you want to delete this task?')) {
+    if (window.confirm(t('task.confirmDelete'))) {
       const result = await actions.deleteTask(taskId);
       if (result.success) {
         loadProjectTasks();
@@ -130,13 +132,13 @@ export default function TaskManager({ projectId, onClose }) {
     <div className="task-manager-overlay">
       <div className="task-manager">
         <div className="task-manager-header">
-          <h2>Task Management</h2>
+          <h2>{t('task.management')}</h2>
           <div className="header-actions">
-            <button 
+            <button
               className="btn-primary"
               onClick={() => setShowTaskForm(true)}
             >
-              + Add Task
+              {t('task.add')}
             </button>
             <button className="btn-close" onClick={onClose}>×</button>
           </div>
@@ -145,11 +147,11 @@ export default function TaskManager({ projectId, onClose }) {
         {showTaskForm && (
           <div className="task-form-container">
             <form onSubmit={handleSubmit} className="task-form">
-              <h3>{editingTask ? 'Edit Task' : 'Create New Task'}</h3>
+              <h3>{editingTask ? t('task.edit') : t('task.create')}</h3>
               
               <div className="form-row">
                 <div className="form-group">
-                  <label>Task Title *</label>
+                  <label>{t('task.title')}</label>
                   <input
                     type="text"
                     value={formData.title}
@@ -158,20 +160,20 @@ export default function TaskManager({ projectId, onClose }) {
                   />
                 </div>
                 <div className="form-group">
-                  <label>Priority</label>
+                  <label>{t('task.priority')}</label>
                   <select
                     value={formData.priority}
                     onChange={(e) => setFormData({...formData, priority: e.target.value})}
                   >
-                    <option value="low">Low</option>
-                    <option value="medium">Medium</option>
-                    <option value="high">High</option>
+                    <option value="low">{t('general.low')}</option>
+                    <option value="medium">{t('general.medium')}</option>
+                    <option value="high">{t('general.high')}</option>
                   </select>
                 </div>
               </div>
 
               <div className="form-group">
-                <label>Description</label>
+                <label>{t('task.description')}</label>
                 <textarea
                   value={formData.description}
                   onChange={(e) => setFormData({...formData, description: e.target.value})}
@@ -181,19 +183,19 @@ export default function TaskManager({ projectId, onClose }) {
 
               <div className="form-row">
                 <div className="form-group">
-                  <label>Status</label>
+                  <label>{t('task.status')}</label>
                   <select
                     value={formData.status}
                     onChange={(e) => setFormData({...formData, status: e.target.value})}
                   >
-                    <option value="todo">To Do</option>
-                    <option value="in-progress">In Progress</option>
-                    <option value="review">Review</option>
-                    <option value="completed">Completed</option>
+                    <option value="todo">{t('general.toDo')}</option>
+                    <option value="in-progress">{t('general.inProgress')}</option>
+                    <option value="review">{t('general.review')}</option>
+                    <option value="completed">{t('general.completed')}</option>
                   </select>
                 </div>
                 <div className="form-group">
-                  <label>Due Date</label>
+                  <label>{t('task.dueDate')}</label>
                   <input
                     type="date"
                     value={formData.dueDate}
@@ -204,7 +206,7 @@ export default function TaskManager({ projectId, onClose }) {
 
               <div className="form-actions">
                 <button type="submit" className="btn-primary">
-                  {editingTask ? 'Update Task' : 'Create Task'}
+                  {editingTask ? t('task.update') : t('task.createButton')}
                 </button>
                 <button 
                   type="button" 
@@ -214,7 +216,7 @@ export default function TaskManager({ projectId, onClose }) {
                     setEditingTask(null);
                   }}
                 >
-                  Cancel
+                  {t('general.cancel')}
                 </button>
               </div>
             </form>
@@ -224,7 +226,7 @@ export default function TaskManager({ projectId, onClose }) {
         <div className="task-list">
           {tasks.length === 0 ? (
             <div className="empty-state">
-              <p>No tasks yet. Create your first task to get started!</p>
+              <p>{t('task.none')}</p>
             </div>
           ) : (
             <div className="task-grid">
@@ -265,16 +267,16 @@ export default function TaskManager({ projectId, onClose }) {
                               onChange={(e) => handleStatusChange(task.id, e.target.value)}
                               className="status-select"
                             >
-                              <option value="todo">To Do</option>
-                              <option value="in-progress">In Progress</option>
-                              <option value="review">Review</option>
-                              <option value="completed">Completed</option>
+                              <option value="todo">{t('general.toDo')}</option>
+                              <option value="in-progress">{t('general.inProgress')}</option>
+                              <option value="review">{t('general.review')}</option>
+                              <option value="completed">{t('general.completed')}</option>
                             </select>
                             
                             <button
                               className="btn-edit"
                               onClick={() => handleEdit(task)}
-                              title="Edit task"
+                              title={t('task.editTitle')}
                             >
                               ✏️
                             </button>
@@ -282,7 +284,7 @@ export default function TaskManager({ projectId, onClose }) {
                             <button
                               className="btn-delete"
                               onClick={() => handleDelete(task.id)}
-                              title="Delete task"
+                              title={t('task.deleteTitle')}
                             >
                               🗑️
                             </button>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,25 @@
+import { useState, useCallback } from 'react'
+import en from '../app/i18n/en.json' assert { type: 'json' }
+import es from '../app/i18n/es.json' assert { type: 'json' }
+
+const resources = { en, es }
+let currentLang = 'en'
+
+const translate = (key, lang = currentLang) => {
+  return key.split('.').reduce((obj, part) => (obj && obj[part] !== undefined ? obj[part] : key), resources[lang])
+}
+
+export const useTranslation = () => {
+  const [, forceUpdate] = useState(0)
+
+  const t = useCallback((key) => translate(key), [])
+
+  const setLanguage = useCallback((lang) => {
+    if (resources[lang]) {
+      currentLang = lang
+      forceUpdate(n => n + 1)
+    }
+  }, [])
+
+  return { t, language: currentLang, setLanguage }
+}


### PR DESCRIPTION
## Summary
- add english and spanish locale files under `/app/i18n`
- implement lightweight `useTranslation` hook and wire into project/task components
- document translation approach in `/app/docs/i18n/README.md`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d3c583048321ab5175d859dd527e