### PR TITLE
chore: centralize dashboard theme variables

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,9 +4,46 @@
   box-sizing: border-box;
 }
 
+:root {
+  --color-bg: #ffffff;
+  --color-text-dark: #111827;
+  --color-muted: #6b7280;
+  --color-search-bg: #f9fafb;
+  --color-search-input: #374151;
+  --color-placeholder: #9ca3af;
+  --color-settings-bg: #f3f4f6;
+  --color-settings-hover-bg: #e5e7eb;
+  --color-stat-item-hover-bg: #e2e8f0;
+  --color-card-bg: #f8fafc;
+  --color-card-gradient-start: #ffffff;
+  --color-card-gradient-end: #f8fafc;
+  --color-card-border: rgba(0, 0, 0, 0.06);
+  --color-accent-blue: #3b82f6;
+  --color-accent-blue-dark: #2563eb;
+  --color-accent-purple: #8b5cf6;
+  --color-accent-cyan: #06b6d4;
+  --color-secondary-text: #475569;
+  --color-stat-number: #1f2937;
+  --color-stat-trend: #059669;
+  --color-overdue: #dc2626;
+  --color-success: #10b981;
+  --color-danger-bg: #ef4444;
+
+  --font-base: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-s: 10px;
+  --space-md: 12px;
+  --space-lg: 16px;
+  --space-xl: 20px;
+  --space-2xl: 24px;
+  --space-3xl: 30px;
+}
+
 html, body {
   height: 100%;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-family: var(--font-base);
   overflow: hidden;
 }
 
@@ -281,9 +318,9 @@ html, body {
 /* Dashboard Styles */
 .dashboard {
   min-height: 100vh;
-  background: #ffffff;
-  padding: 20px;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: var(--color-bg);
+  padding: var(--space-xl);
+  font-family: var(--font-base);
 }
 
 /* Dashboard Header */
@@ -291,31 +328,31 @@ html, body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 30px;
-  padding: 0 10px;
+  margin-bottom: var(--space-3xl);
+  padding: 0 var(--space-s);
 }
 
 .dashboard-header h1 {
   font-size: 32px;
   font-weight: 600;
-  color: #111827;
+  color: var(--color-text-dark);
   margin: 0;
 }
 
 .header-controls {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: var(--space-xl);
 }
 
 .search-box {
   display: flex;
   align-items: center;
-  background: #f9fafb;
-  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: var(--color-search-bg);
+  border: 1px solid var(--color-card-border);
   border-radius: 8px;
-  padding: 8px 12px;
-  gap: 8px;
+  padding: var(--space-sm) var(--space-md);
+  gap: var(--space-sm);
 }
 
 .search-box input {
@@ -323,39 +360,39 @@ html, body {
   background: none;
   outline: none;
   font-size: 14px;
-  color: #374151;
+  color: var(--color-search-input);
   width: 200px;
 }
 
 .search-box input::placeholder {
-  color: #9ca3af;
+  color: var(--color-placeholder);
 }
 
 .search-icon {
-  color: #6b7280;
+  color: var(--color-muted);
   font-size: 16px;
 }
 
 .settings-btn {
-  background: #f3f4f6;
-  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: var(--color-settings-bg);
+  border: 1px solid var(--color-card-border);
   border-radius: 8px;
-  padding: 8px 16px;
+  padding: var(--space-sm) var(--space-lg);
   font-size: 14px;
-  color: #374151;
+  color: var(--color-search-input);
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .settings-btn:hover {
-  background: #e5e7eb;
+  background: var(--color-settings-hover-bg);
 }
 
 .logout-btn {
-  background: #ef4444;
-  border: 1px solid #dc2626;
+  background: var(--color-danger-bg);
+  border: 1px solid var(--color-overdue);
   border-radius: 8px;
-  padding: 8px 16px;
+  padding: var(--space-sm) var(--space-lg);
   font-size: 14px;
   color: white;
   cursor: pointer;
@@ -363,17 +400,17 @@ html, body {
 }
 
 .logout-btn:hover {
-  background: #dc2626;
+  background: var(--color-overdue);
 }
 
 /* Dashboard Container Base Style */
 .dashboard-container {
-  background: #ffffff;
+  background: var(--color-bg);
   border-radius: 16px;
-  border: 1px solid rgba(0, 0, 0, 0.06);
+  border: 1px solid var(--color-card-border);
   box-shadow: 0 8px 24px rgba(17, 24, 39, 0.08), 0 2px 6px rgba(17, 24, 39, 0.05);
-  margin-bottom: 24px;
-  padding: 24px;
+  margin-bottom: var(--space-2xl);
+  padding: var(--space-2xl);
   position: relative;
 }
 
@@ -397,17 +434,17 @@ html, body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-xl);
   flex-wrap: wrap;
-  gap: 16px;
+  gap: var(--space-lg);
 }
 
 .new-project-btn {
-  background: #3b82f6;
+  background: var(--color-accent-blue);
   color: white;
   border: none;
   border-radius: 8px;
-  padding: 12px 20px;
+  padding: var(--space-md) var(--space-xl);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -415,24 +452,24 @@ html, body {
 }
 
 .new-project-btn:hover {
-  background: #2563eb;
+  background: var(--color-accent-blue-dark);
   transform: translateY(-1px);
 }
 
 .quick-stats {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 20px;
-  margin-bottom: 24px;
+  gap: var(--space-xl);
+  margin-bottom: var(--space-2xl);
 }
 
 .stat-item {
-  background: #f8fafc;
+  background: var(--color-card-bg);
   border: 1px solid rgba(0, 0, 0, 0.04);
   border-radius: 8px;
-  padding: 12px 16px;
+  padding: var(--space-md) var(--space-lg);
   font-size: 14px;
-  color: #475569;
+  color: var(--color-secondary-text);
   font-weight: 500;
   white-space: nowrap;
   text-align: center;
@@ -445,7 +482,7 @@ html, body {
 }
 
 .stat-item.clickable:hover {
-  background: #e2e8f0;
+  background: var(--color-stat-item-hover-bg);
   border-color: rgba(0, 0, 0, 0.08);
   transform: translateY(-1px);
 }
@@ -453,27 +490,27 @@ html, body {
 .stat-number {
   font-size: 24px;
   font-weight: 700;
-  color: #1f2937;
-  margin-bottom: 4px;
+  color: var(--color-stat-number);
+  margin-bottom: var(--space-xs);
 }
 
 .stat-label {
   font-size: 12px;
-  color: #6b7280;
+  color: var(--color-muted);
   font-weight: 500;
 }
 
 /* Enhanced Stat Cards */
 .stat-card {
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: linear-gradient(135deg, var(--color-card-gradient-start) 0%, var(--color-card-gradient-end) 100%);
+  border: 1px solid var(--color-card-border);
   border-radius: 16px;
-  padding: 24px;
+  padding: var(--space-2xl);
   cursor: pointer;
   transition: all 0.3s ease;
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--space-lg);
   position: relative;
   overflow: hidden;
 }
@@ -485,7 +522,7 @@ html, body {
   left: 0;
   right: 0;
   height: 4px;
-  background: linear-gradient(90deg, #3b82f6, #8b5cf6, #06b6d4);
+  background: linear-gradient(90deg, var(--color-accent-blue), var(--color-accent-purple), var(--color-accent-cyan));
   opacity: 0;
   transition: opacity 0.3s ease;
 }
@@ -519,26 +556,26 @@ html, body {
 .stat-card .stat-number {
   font-size: 32px;
   font-weight: 700;
-  color: #1f2937;
-  margin-bottom: 4px;
+  color: var(--color-stat-number);
+  margin-bottom: var(--space-xs);
   line-height: 1;
 }
 
 .stat-card .stat-label {
   font-size: 14px;
-  color: #6b7280;
+  color: var(--color-muted);
   font-weight: 600;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-sm);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .stat-trend {
   font-size: 12px;
-  color: #059669;
+  color: var(--color-stat-trend);
   font-weight: 500;
   background: rgba(5, 150, 105, 0.1);
-  padding: 4px 8px;
+  padding: var(--space-xs) var(--space-sm);
   border-radius: 6px;
   display: inline-block;
 }
@@ -553,7 +590,7 @@ html, body {
 }
 
 .stat-card.overdue-tasks .stat-trend {
-  color: #dc2626;
+  color: var(--color-overdue);
   background: rgba(220, 38, 38, 0.1);
 }
 
@@ -573,10 +610,10 @@ html, body {
   background: rgba(59, 130, 246, 0.05);
   border: 1px solid rgba(59, 130, 246, 0.1);
   border-radius: 12px;
-  padding: 12px 20px;
-  margin: 16px 20px;
+  padding: var(--space-md) var(--space-xl);
+  margin: var(--space-lg) var(--space-xl);
   font-size: 12px;
-  color: #374151;
+  color: var(--color-search-input);
 }
 
 .status-item {
@@ -589,12 +626,12 @@ html, body {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: #10b981;
+  background: var(--color-success);
   animation: pulse 2s infinite;
 }
 
 .status-dot.active {
-  background: #10b981;
+  background: var(--color-success);
 }
 
 @keyframes pulse {


### PR DESCRIPTION
## Summary
- define reusable color, font, and spacing tokens in a new `:root` theme block
- refactor dashboard and stat card styles to consume variables instead of hard-coded hex values

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dcde7ac08321a79725e6901cfaa8